### PR TITLE
fix: Set Firebase hosting to use dist folder for Vite builds

### DIFF
--- a/web-app/.gitignore
+++ b/web-app/.gitignore
@@ -12,6 +12,12 @@ dist
 dist-ssr
 *.local
 
+# Firebase
+.firebase/
+
+# Claude Code local settings
+.claude/settings.local.json
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/web-app/firebase.json
+++ b/web-app/firebase.json
@@ -1,6 +1,6 @@
 {
   "hosting": {
-    "public": ".",
+    "public": "dist",
     "ignore": [
       "firebase.json",
       "**/.*",


### PR DESCRIPTION
  主な修正内容：
  - firebase.jsonで"public": "dist"に変更
  - 正しいViteビルドを実行してVueアプリケーションをバンドル